### PR TITLE
Added feature: Class codes display in admin > manage > registration

### DIFF
--- a/public/language/en-GB/admin/menu.json
+++ b/public/language/en-GB/admin/menu.json
@@ -13,7 +13,7 @@
 	"manage/tags": "Tags",
 	"manage/users": "Users",
 	"manage/admins-mods": "Admins & Mods",
-	"manage/registration": "Registration Queue",
+	"manage/registration": "Registration",
 	"manage/post-queue": "Post Queue",
 	"manage/groups": "Groups",
 	"manage/ip-blacklist": "IP Blacklist",

--- a/public/language/en-US/admin/manage/registration.json
+++ b/public/language/en-US/admin/manage/registration.json
@@ -16,5 +16,11 @@
 	"invitations.invitee-email": "Invitee Email",
 	"invitations.invitee-username": "Invitee Username (if registered)",
 
-	"invitations.confirm-delete": "Are you sure you wish to delete this invitation?"
+	"invitations.confirm-delete": "Are you sure you wish to delete this invitation?",
+
+	"class-codes": "Class Codes",
+	"class-codes.description": "Below are the class codes for each group to register for the class.",
+	"class-codes.prof-code": "Professors: prof holder",
+	"class-codes.ta-code": "Teaching Assistans: ta holder",
+	"class-codes.student-code": "Students: student holder"
 } 

--- a/public/language/en-US/admin/menu.json
+++ b/public/language/en-US/admin/menu.json
@@ -13,7 +13,7 @@
 	"manage/tags": "Tags",
 	"manage/users": "Users",
 	"manage/admins-mods": "Admins & Mods",
-	"manage/registration": "Registration Queue",
+	"manage/registration": "Registration",
 	"manage/post-queue": "Post Queue",
 	"manage/groups": "Groups",
 	"manage/ip-blacklist": "IP Blacklist",

--- a/public/language/en-US/admin/settings/user.json
+++ b/public/language/en-US/admin/settings/user.json
@@ -40,7 +40,7 @@
 	"registration-type.invite-only": "Invite Only",
 	"registration-type.admin-invite-only": "Admin Invite Only",
 	"registration-type.disabled": "No registration",
-	"registration-type.help": "Normal - Users can register from the /register page.<br/>\nInvite Only - Users can invite others from the <a href=\"%1/users\" target=\"_blank\">users</a> page.<br/>\nAdmin Invite Only - Only administrators can invite others from <a href=\"%1/users\" target=\"_blank\">users</a> and <a href=\"%1/admin/manage/users\">admin/manage/users</a> pages.<br/>\nNo registration - No user registration.<br/>",
+	"registration-type.help": "Normal - Users can register from the /register page.<br/>\nInvite Only - Users can invite others from the <a href=\"%1/users\" target=\"_blank\">users</a> page.<br/>\nAdmin Invite Only - Only administrators can invite others from <a href=\"%1/users\" target=\"_blank\">users</a> and <a href=\"%1/admin/manage/users\">admin/manage/users</a> pages and the input of the class code is required.<br/>\nNo registration - No user registration.<br/>",
 	"registration-approval-type.help": "Normal - Users are registered immediately.<br/>\nAdmin Approval - User registrations are placed in an <a href=\"%1/admin/manage/registration\">approval queue</a> for administrators.<br/>\nAdmin Approval for IPs - Normal for new users, Admin Approval for IP addresses that already have an account.<br/>",
 	"registration-queue-auto-approve-time": "Automatic Approval Time",
 	"registration-queue-auto-approve-time-help": "Hours before user is approved automatically. 0 to disable.",

--- a/src/views/admin/manage/registration.tpl
+++ b/src/views/admin/manage/registration.tpl
@@ -128,5 +128,25 @@
                 </table>
             </div>
         </div>
+
+        <div class="class-codes panel panel-success">
+            <div class="panel-heading">
+                [[admin/manage/registration:class-codes]]
+            </div>
+            <p class="panel-body">
+                [[admin/manage/registration:class-codes.description]]
+            </p>
+            <div class="table-responsive">
+                <table class="table table-striped users-list">
+                    <thead>
+                        <tr>
+                            <th>[[admin/manage/registration:class-codes.prof-code]]</th>
+                            <th>[[admin/manage/registration:class-codes.ta-code]]</th>
+                            <th>[[admin/manage/registration:class-codes.student-code]]</th>
+                        </tr>
+                    </thead>
+                </table>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Created a section in admin > manage > registration that displays a table with each of the codes. "Registration Queue" menu was changed to the more general name of "Registration". There's no backend code generation yet (dependent on #20) but the display itself is working. I only changed .tpl and .json files, so no javascript to typescript conversion was necessary.

![image](https://github.com/CMU-313/fall23-nodebb-jasta/assets/122938541/97cb49b6-9254-424c-b20b-0b309974eb60)

Resolves #27 