### PR TITLE
Anonymous posts test

### DIFF
--- a/test/posts.js
+++ b/test/posts.js
@@ -31,6 +31,7 @@ describe('Post\'s', () => {
     let postData;
     let topicData;
     let cid;
+    let isAnonymous;
 
     before((done) => {
         async.series({
@@ -1225,6 +1226,32 @@ describe('Post\'s', () => {
                 const events = await topics.events.get(tid1, 1);
                 assert(events);
                 assert.strictEqual(events.length, 0);
+            });
+        });
+    });
+
+    describe('Anonymous Posts', () => {
+        it('should create an anonymous reply', (done) => {
+            topics.post({
+                uid: voterUid,
+                cid: cid,
+                title: 'topic to edit',
+                content: 'A post to for anonymous testing',
+                isAnonymous: isAnonymous,
+            }, (err, data) => {
+                assert.ifError(err);
+                assert.equal(isAnonymous, data.postData.isAnonymous);
+            });
+        });
+        it('should create an anonymous reply', (done) => {
+            topics.reply({
+                uid: voterUid,
+                tid: topicData.tid,
+                content: 'raw content',
+                isAnonymous: isAnonymous
+            }, (err, postData) => {
+                assert.ifError(err);
+                assert.equal(isAnonymous, postData.isAnonymous);
             });
         });
     });

--- a/test/posts.js
+++ b/test/posts.js
@@ -31,7 +31,6 @@ describe('Post\'s', () => {
     let postData;
     let topicData;
     let cid;
-    let isAnonymous;
 
     before((done) => {
         async.series({
@@ -1231,27 +1230,44 @@ describe('Post\'s', () => {
     });
 
     describe('Anonymous Posts', () => {
-        it('should create an anonymous main post', (done) => {
+        let isAnonymous = true;
+        let studentUid;
+        before((done) => {
+            async.series({
+                studentUid: function (next) {
+                    user.create({ username: 'student' }, next);
+                },
+            }, (err, results) => {
+                if (err) {
+                    return done(err);
+                }
+                studentUid = results.studentUid;
+            });
+        });
+
+        it('should create an anonymous main post', async () => {
             topics.post({
-                uid: voterUid,
-                cid: cid,
+                uid: studentUid,
+                cid,
                 title: 'topic to edit',
                 content: 'A post to for anonymous testing',
                 isAnonymous: isAnonymous,
             }, (err, data) => {
                 assert.ifError(err);
                 assert.equal(isAnonymous, data.postData.isAnonymous);
+                assert.equal("Anonymous User", data.postData.displayname);
             });
         });
-        it('should create an anonymous reply', (done) => {
+        it('should create an anonymous reply', async () => {
             topics.reply({
-                uid: voterUid,
+                uid: studentUid,
                 tid: topicData.tid,
                 content: 'raw content',
                 isAnonymous: isAnonymous
             }, (err, postData) => {
                 assert.ifError(err);
                 assert.equal(isAnonymous, postData.isAnonymous);
+                assert.equal("Anonymous User", postData.displayname);
             });
         });
     });

--- a/test/posts.js
+++ b/test/posts.js
@@ -1231,7 +1231,7 @@ describe('Post\'s', () => {
     });
 
     describe('Anonymous Posts', () => {
-        it('should create an anonymous reply', (done) => {
+        it('should create an anonymous main post', (done) => {
             topics.post({
                 uid: voterUid,
                 cid: cid,

--- a/test/posts.js
+++ b/test/posts.js
@@ -1240,7 +1240,7 @@ describe('Post\'s', () => {
             TopicPostData = await topics.post({
                 uid: studentUid,
                 cid: cid,
-                title: 'topic to with anonymous posts',
+                title: 'topic with anonymous posts',
                 content: 'Anonymous testing',
                 isAnonymous: isAnonymous});
             assert.equal(isAnonymous, TopicPostData.postData.isAnonymous);
@@ -1260,7 +1260,7 @@ describe('Post\'s', () => {
             TopicPostData = await topics.post({
                 uid: studentUid,
                 cid: cid,
-                title: 'topic to with anonymous posts',
+                title: 'topic with anonymous posts',
                 content: 'Anonymous testing',
                 isAnonymous: isAnonymous});
             


### PR DESCRIPTION
Added tests for anonymous posts option in the tests/posts.js file. 

The tests check if the isAnonymous post field reflects true if we create an anonymous post, and checks if the displayname of the posts is changed to "Anonymous User". This was tested for both main posts and replies. Another test was implemented to see if instructors, or global moderators were able to still see the poster's name even if the post was anonymous in the format "Anonymous User (<username>)".

We will use this for testing the anonymous posts option before merging into main.