### PR TITLE
User guide for anonymous posts

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -39,3 +39,44 @@ This guide provides detailed instructions on how to use and user test the new em
     -   The test checks all aspects of the default configuration setting, ensuring that every part of the configuration is correctly applied.
     -   The test interacts with the `Emailer.setupFallbackTransport` method directly, ensuring that any changes to this method are verified by the test.
     -   The usage of assertions ensures that any discrepancies in the default configuration will result in a failed test.
+
+
+# User Instruction for Anonymous Posts
+
+This guide provides detailed instructions on how to use and user test the new anonymous posts feature, as well as an overview of the automated tests associated with this feature.
+
+#### How to create an anonymous post:
+
+1.  **Setup**:
+
+    -  Ensure you have the latest version of NodeBB installed and built
+    -  Login to an account on NodeBB
+2.  **Creating Anonymous Posts**:
+
+    -  In NodeBB, navigate to any category (eg. Announcements) and click “New Topic”
+    -  In the popup that appears to create a new post, there should be a switch labeled “Anonymous Post?” under the tools bar containing the options for formatting the text of your post
+    -  Turn that switch on if you want your new post to be anonymous, and make a post as you would normally do otherwise
+    -  If the “Anonymous Post?” button is on, the resulting post should have “Anonymous User” displayed rather than a user’s username
+    -  Note that if the account is an admin or a moderator, the name displayed will also show the poster’s username in parentheses after “Anonymous User”
+
+#### User Testing the Feature:
+
+1.  **Initial Setup (N/A)**:
+    -  Navigate to the NodeBB repository
+    -  Run `npm run test` in a terminal
+
+#### Automated Tests:
+
+-   **Location**: The automated tests for this feature can be found in the `test/posts.js` file starting on line 1237 in the “Anonymous Posts” section of the tests
+
+-   **Description**:
+
+    -   Each of the tests create a post with the isAnonymous field in the postData set to true.
+    -   The first test, labeled “should create an anonymous main post” creates a new topic and ensures that the resulting main post has the isAnonymous set to true. It also ensures that the display name is “Anonymous User”
+    -   The second test, labeled “should create an anonymous reply” creates a reply under a topic and ensures that the resulting post has the isAnonymous set to true. It also ensures that the display name is “Anonymous User”
+    -   The third test, labeled “instructors should still see user name” creates a post as a student and ensures that the resulting post has the isAnonymous set to true. It also ensures that if the user requesting to see the post is an admin or moderator, they will still be able to see the student’s username in the post.
+    -   All checks were conducted through assert statements
+
+-   **Why These Tests are Sufficient**:
+    -   These tests are sufficient because they check that a post is made correctly, post as a reply or a main post in a topic, when their isAnonymous field is set to true
+    -   They also ensure that their display name shows “Anonymous User” when the field "isAnonymous" is true. Given that the field displayname in a post was only changed under the condition that the field “isAnonymous” field is true, all other functions of a post stayed the same. 


### PR DESCRIPTION
Added instructions in the `UserGuide.md` file for creating an anonymous posts, as well as details on the tests added to test this feature and how to run them. 