### PR TITLE
Installed Static Analysis Tool Flow

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{ "presets": ["@babel/preset-flow"] }

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ feeds/recent.rss
 .eslintcache
 .svn
 dump.rdb
+lib/
+.flowconfig
 
 logs/
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
         "lint": "npx tsc && eslint --cache ./nodebb .",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+        "build": "babel src/ -d lib/",
+        "prepublish": "yarn run build",
+        "flow": "flow"
     },
     "nyc": {
         "exclude": [
@@ -147,6 +150,9 @@
     },
     "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
+        "@babel/cli": "^7.23.0",
+        "@babel/core": "^7.23.2",
+        "@babel/preset-flow": "^7.22.15",
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-angular": "17.3.0",
         "@types/async": "^3.2.16",
@@ -161,6 +167,7 @@
         "eslint": "^8.31.0",
         "eslint-config-nodebb": "0.2.1",
         "eslint-plugin-import": "2.26.0",
+        "flow-bin": "^0.219.4",
         "grunt": "^1.5.3",
         "grunt-contrib-watch": "1.1.0",
         "husky": "8.0.2",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -98,7 +98,6 @@ prestart.versionCheck();
 
 if (!configExists && process.argv[2] !== 'setup') {
     require('./setup').webInstall();
-    return;
 }
 
 process.env.CONFIG = configFile;


### PR DESCRIPTION
Added the required scripts and packages to packages.json to run flow, a static typechecker for JavaScript. To run flow for the first time, run the two commands `npm run flow init` and `npm run flow`. For successive uses of flow, `npm run flow` by itself is sufficient. The results of running flow can be seen below.
![image](https://github.com/CMU-313/fall23-nodebb-jasta/assets/58605689/34d75215-95b9-4a4e-b654-c9690efc7bdb)
